### PR TITLE
Add sdk check for large title

### DIFF
--- a/ShortcutsCollectionView/ViewController.swift
+++ b/ShortcutsCollectionView/ViewController.swift
@@ -25,7 +25,11 @@ class ViewController: UICollectionViewController, UICollectionViewDelegateFlowLa
     fileprivate func setupNavigationBarController() {
         self.navigationController?.navigationBar.shadowImage = UIImage()
         navigationItem.title = "Lists"
-        navigationController?.navigationBar.prefersLargeTitles = true
+
+        if #available(iOS 11.0, *) {
+                self.navigationController?.navigationBar.prefersLargeTitles = true
+        }
+
         navigationItem.setRightBarButton(UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addNewList)), animated: true)
     }
     fileprivate func setupCollectionView() {

--- a/ShortcutsCollectionView/ViewController.swift
+++ b/ShortcutsCollectionView/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UICollectionViewController, UICollectionViewDelegateFlowLa
         navigationItem.title = "Lists"
 
         if #available(iOS 11.0, *) {
-                self.navigationController?.navigationBar.prefersLargeTitles = true
+            self.navigationController?.navigationBar.prefersLargeTitles = true
         }
 
         navigationItem.setRightBarButton(UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addNewList)), animated: true)


### PR DESCRIPTION
This adds a check when setting the `prefersLargeTitles` property as it is [supported in iOS 11.0+](https://developer.apple.com/documentation/uikit/uinavigationbar/2908999-preferslargetitles).

Thank you for a great example on how to replicate apple's shortcuts app with a collection view, @HassanElDesouky!